### PR TITLE
Create BAMS.yaml

### DIFF
--- a/jettons/BAMS.yaml
+++ b/jettons/BAMS.yaml
@@ -1,11 +1,14 @@
-{
-  "address": "0:2ad108dfc4565587d37993c60cd81ed99b2eb175b99777aee174cbb5a257b219",
-  "name": "Bullrun Ambassadors Members Syndicate",
-  "symbol": "BAMS",
-  "decimals": "9",
-  "image": "https://cache.tonapi.io/imgproxy/TSNQk2BFD7SwfDF7BIQXZGpb8aw3tMj9OJc8m8LFe34/rs:fill:200:200:1/g:no/aHR0cHM6Ly9pcGZzLmhvdGRhby5haS9pcGZzL2JjaXFuYXgyc3dyZm13aTdlM2RoZWZveXk1NnNjYWFwcTNoMmxqYm1ja2xvc3g2cWRsN3FmZW9x.webp",
-  "description": "First Members Syndicate as a Cult of Fun, Giweaways, Education and Entertainment "
-}
+
+name: Bullrun Ambassadors Members Syndicate
+
+description: First Members Syndicate as a Cult of Fun, Giweaways, Education and Entertainment
+
+image: "https://raw.githubusercontent.com/BullrunAmbassadors/BAMS/refs/heads/main/logo.jpg"
+
+address: EQAq0QjfxFZVh9N5k8YM2B7Zmy6xdbmXd67hdMu1oleyGWmk
+
+symbol: BAMS
+
 websites:
   - "https://bullrunambassadors.space/bams"
 social:


### PR DESCRIPTION

name: Bullrun Ambassadors Members Syndicate

description: First Members Syndicate as a Cult of Fun, Giweaways, Education and Entertainment

image: "https://raw.githubusercontent.com/BullrunAmbassadors/BAMS/refs/heads/main/logo.jpg"

address: EQAq0QjfxFZVh9N5k8YM2B7Zmy6xdbmXd67hdMu1oleyGWmk

symbol: BAMS

websites:
  - "https://bullrunambassadors.space/bams"
social:
  - "https://t.me/bam_syndicate"
  - "https://t.me/bams_official"
  - "https://x.com/BullAmbSummit"